### PR TITLE
Allow to log client in with access token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wbce-d9/sdk",
-	"version": "10.3.3",
+	"version": "10.3.5",
 	"description": "The official Directus9 SDK for use in JavaScript!",
 	"repository": "directus9/sdk",
 	"main": "dist/sdk.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wbce-d9/sdk",
-	"version": "10.3.5",
+	"version": "10.3.6",
 	"description": "The official Directus9 SDK for use in JavaScript!",
 	"repository": "directus9/sdk",
 	"main": "dist/sdk.cjs.js",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -36,6 +36,7 @@ export abstract class IAuth {
 	abstract readonly password: PasswordsHandler;
 
 	abstract login(credentials: AuthCredentials): Promise<AuthResult>;
+	abstract setAuthResult(auth: AuthResult): void;
 	abstract refresh(): Promise<AuthResult | false>;
 	abstract refreshIfExpired(): Promise<void>;
 	abstract static(token: AuthToken): Promise<boolean>;

--- a/src/base/auth.ts
+++ b/src/base/auth.ts
@@ -147,6 +147,10 @@ export class Auth extends IAuth {
 		};
 	}
 
+	async setAuthResult(auth: AuthResult) {
+		this.updateStorage(auth);
+	}
+
 	async static(token: AuthToken): Promise<boolean> {
 		if (!this.staticToken) this.staticToken = token;
 


### PR DESCRIPTION
This allows some other login flows (for example SSO) to be used with the client.